### PR TITLE
Feature/15 diaryList_DiffandSwipe

### DIFF
--- a/app/src/main/java/com/mindgarden/mindgarden/ui/diarylist/DiaryListDiffCallback.kt
+++ b/app/src/main/java/com/mindgarden/mindgarden/ui/diarylist/DiaryListDiffCallback.kt
@@ -5,7 +5,7 @@ import com.mindgarden.mindgarden.data.model.Diary
 
 object DiaryListDiffCallback : DiffUtil.ItemCallback<Diary>() {
     override fun areItemsTheSame(oldItem: Diary, newItem: Diary): Boolean {
-        return (oldItem.idx == newItem.idx && oldItem.content == newItem.content)
+        return oldItem.idx == newItem.idx
     }
 
     override fun areContentsTheSame(oldItem: Diary, newItem: Diary): Boolean {


### PR DESCRIPTION
** 노션에 정리했습니다.
** 참고
[DiffUtil](https://velog.io/@l2hyunwoo/Android-RecyclerView-DiffUtil-ListAdapter)
[Swipe](https://velog.io/@trycatch98/Android-RecyclerView-Swipe-Menu#reference)
[ItemTouchHelper](https://developer.android.com/reference/androidx/recyclerview/widget/ItemTouchHelper)
[ItemTouchHelper.Callback](https://developer.android.com/reference/androidx/recyclerview/widget/ItemTouchHelper.Callback)
[ItemTouchUIUtil](https://developer.android.com/reference/androidx/recyclerview/widget/ItemTouchUIUtil)

( Swipe 의 경우, 아직 온전히 이해하지 못해서 설명이 부족합니다. 더는 늦으면 안 될 거 같아 PR 올렸습니다... )

**[ DiffUtil ]** : 전체 리스트가 아닌 변경이 필요한 데이터만 변경되도록 한다.
1. DiffUtil 에 대한 콜백 클래스 구현
2. ListAdapter 구현

**[ Swipe ]**
- Swipe 동작
- Dialog 삭제 (LongClick)

<img src="https://user-images.githubusercontent.com/44170716/126067562-30be55d1-962f-411d-8087-883c3b7d0f1a.gif" width="200" height="400">

1. ItemTouchHelper
→ swipe to dismiss , drag & drop 등을 쉽게 구현할 수 있음
→ ItemTouchHelper.Callback 클래스 구현
→ item view 전체가 swipe 되는 게 아니라 앞 view 만 swipe 되도록 하려면 ItemTouchUIUtil 을 이용